### PR TITLE
Minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ install(PROGRAMS
 # Install examples
 set(EXAMPLES_DIR examples)
 install(PROGRAMS
-    ${EXAMPLES_DIR}train_enjoy.bash
+    ${EXAMPLES_DIR}/train_enjoy.bash
     DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/drl_grasping.repos
+++ b/drl_grasping.repos
@@ -1,25 +1,33 @@
 repositories:
-  gym-ignition:
-    type: git
-    url: https://github.com/AndrejOrsula/gym-ignition.git
-    branch: drl_grasping
   ros_ign:
     type: git
     url: https://github.com/ignitionrobotics/ros_ign.git
-    branch: ros2
+    version: ros2
   ign_moveit2:
     type: git
     url: https://github.com/AndrejOrsula/ign_moveit2.git
-    branch: master
+    version: python_interface
   panda_ign:
     type: git
     url: https://github.com/AndrejOrsula/panda_ign.git
-    branch: master
+    version: master
   panda_moveit2_config:
     type: git
     url: https://github.com/AndrejOrsula/panda_moveit2_config.git
-    branch: master
-  O-CNN:
-    type: git
-    url: https://github.com/AndrejOrsula/O-CNN.git
-    branch: master
+    version: master
+
+  ## Unfortunately, moveit2 cannot be built with symlink-install option yet. Therefore build/install separately if possible.
+  # moveit2:
+  #   type: git
+  #   url: https://github.com/ros-planning/moveit2.git
+  #   version: master
+
+  ## Additional repos that cannot be built with colcon out of the box
+  # gym-ignition:
+  #   type: git
+  #   url: https://github.com/AndrejOrsula/gym-ignition.git
+  #   version: drl_grasping
+  # O-CNN:
+  #   type: git
+  #   url: https://github.com/microsoft/O-CNN.git
+  #   version: master

--- a/drl_grasping/__init__.py
+++ b/drl_grasping/__init__.py
@@ -1,3 +1,6 @@
+# Must be included prior to gym_ignition and/or stable_baselines3
+import open3d
+
 from . import algorithms
 from . import control
 from . import envs

--- a/drl_grasping/envs/tasks/grasp/grasp_octree.py
+++ b/drl_grasping/envs/tasks/grasp/grasp_octree.py
@@ -33,6 +33,7 @@ class GraspOctree(Grasp, abc.ABC):
                  required_object_height: float = 0.25,
                  octree_depth: int = 5,
                  octree_full_depth: int = 2,
+                 octree_include_color: bool = False,
                  verbose: bool = False,
                  **kwargs):
 
@@ -64,6 +65,7 @@ class GraspOctree(Grasp, abc.ABC):
                                             max_bound=max_bound,
                                             depth=octree_depth,
                                             full_depth=octree_full_depth,
+                                            include_color=octree_include_color,
                                             use_sim_time=True,
                                             debug_draw=False,
                                             node_name=f'drl_grasping_octree_creator_{self.id}')

--- a/drl_grasping/envs/tasks/reach/reach_octree.py
+++ b/drl_grasping/envs/tasks/reach/reach_octree.py
@@ -29,6 +29,7 @@ class ReachOctree(Reach, abc.ABC):
                  required_accuracy: float = 0.05,
                  octree_depth: int = 6,
                  octree_full_depth: int = 2,
+                 octree_include_color: bool = False,
                  verbose: bool = False,
                  **kwargs):
 
@@ -56,6 +57,7 @@ class ReachOctree(Reach, abc.ABC):
                                             max_bound=max_bound,
                                             depth=octree_depth,
                                             full_depth=octree_full_depth,
+                                            include_color=octree_include_color,
                                             use_sim_time=True,
                                             debug_draw=False,
                                             node_name=f'drl_grasping_octree_creator_{self.id}')


### PR DESCRIPTION
- Fix path to examples during install
- Fix `.repos` dependencies
   - Include only ROS-project that can be built with `colcon` using `--symlink-install`
   - Replace `branch` keyword with `version`
- Import `open3d` before other dependencies to resolve random segfault