### PR TITLE
Add stacked octree observations

### DIFF
--- a/drl_grasping/algorithms/sac/policies.py
+++ b/drl_grasping/algorithms/sac/policies.py
@@ -1,4 +1,5 @@
 from drl_grasping.algorithms.common.features_extractor import OctreeCnnFeaturesExtractor
+from drl_grasping.algorithms.common.octree_replay_buffer import preprocess_stacked_octree_batch
 from stable_baselines3.common.policies import register_policy, ContinuousCritic
 from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
 from stable_baselines3.common.utils import is_vectorized_observation
@@ -265,20 +266,15 @@ class OctreeCnnPolicy(SACPolicy):
         vectorized_env = is_vectorized_observation(
             observation, self.observation_space)
 
-        # Get original octree size
-        octree_size = np.frombuffer(buffer=observation[-4:],
-                                    dtype='uint32',
-                                    count=1)
-        # Convert to tensor
-        octree = th.from_numpy(observation[:octree_size[0]])
         if self._debug_write_octree:
-            ocnn.write_octree(octree, 'octree.octree')
+            ocnn.write_octree(observation[-1], 'octree.octree')
 
-        # Make batch outo of tensor
-        observation = ocnn.octree_batch([octree]).to(self.device)
+        # Make batch out of tensor (consisting of n-stacked frames)
+        octree_batch = preprocess_stacked_octree_batch(observation)
 
         with th.no_grad():
-            actions = self._predict(observation, deterministic=deterministic)
+            actions = self._predict(octree_batch.to(self.device),
+                                    deterministic=deterministic)
         # Convert to numpy
         actions = actions.cpu().numpy()
 

--- a/drl_grasping/algorithms/sac/sac.py
+++ b/drl_grasping/algorithms/sac/sac.py
@@ -11,7 +11,7 @@ import numpy as np
 import torch as th
 
 
-old_store_transition = SAC._store_transition
+__old_store_transition__ = SAC._store_transition
 
 
 def _setup_model_store_init_and_reset_ent_coef(self) -> None:
@@ -68,13 +68,13 @@ def _store_transition_allow_exploration_reset(
         infos: List[Dict[str, Any]]):
 
     # Chain up original implementation
-    old_store_transition(self,
-                         replay_buffer=replay_buffer,
-                         buffer_action=buffer_action,
-                         new_obs=new_obs,
-                         reward=reward,
-                         done=done,
-                         infos=infos)
+    __old_store_transition__(self,
+                             replay_buffer=replay_buffer,
+                             buffer_action=buffer_action,
+                             new_obs=new_obs,
+                             reward=reward,
+                             done=done,
+                             infos=infos)
 
     if infos[0].get("curriculum.restart_exploration", False):
         if self.ent_coef_optimizer is not None:

--- a/drl_grasping/envs/tasks/__init__.py
+++ b/drl_grasping/envs/tasks/__init__.py
@@ -65,6 +65,7 @@ register(
             'octree_depth': 5,
             'octree_full_depth': 2,
             'octree_include_color': False,
+            'octree_n_stacked': 2,
             'octree_max_size': 20000,
             'verbose': False,
             })
@@ -83,6 +84,7 @@ register(
             'octree_depth': 5,
             'octree_full_depth': 2,
             'octree_include_color': True,
+            'octree_n_stacked': 2,
             'octree_max_size': 25000,
             'verbose': False,
             })
@@ -115,6 +117,7 @@ register(
             'octree_depth': 5,
             'octree_full_depth': 2,
             'octree_include_color': False,
+            'octree_n_stacked': 2,
             'octree_max_size': 30000,
             'verbose': False,
             })
@@ -143,6 +146,7 @@ register(
             'octree_depth': 5,
             'octree_full_depth': 2,
             'octree_include_color': True,
+            'octree_n_stacked': 2,
             'octree_max_size': 40000,
             'verbose': False,
             })

--- a/drl_grasping/envs/tasks/grasp/grasp.py
+++ b/drl_grasping/envs/tasks/grasp/grasp.py
@@ -29,7 +29,7 @@ class Grasp(Manipulation, abc.ABC):
     _workspace_volume: Tuple[float, float, float] = (0.5, 0.5, 0.5)
 
     _ground_enable: bool = True
-    _ground_position: Tuple[float, float, float] = (0.0, 0, 0)
+    _ground_position: Tuple[float, float, float] = (0, 0, 0)
     _ground_quat_xyzw: Tuple[float, float, float, float] = (0, 0, 0, 1)
     _ground_size: Tuple[float, float] = (2.0, 2.0)
 

--- a/drl_grasping/envs/tasks/manipulation.py
+++ b/drl_grasping/envs/tasks/manipulation.py
@@ -9,7 +9,6 @@ from itertools import count
 from scipy.spatial.transform import Rotation
 from typing import List, Tuple, Union
 import abc
-import gym
 import numpy as np
 
 
@@ -53,7 +52,7 @@ class Manipulation(task.Task, abc.ABC):
     _camera_ros2_bridge_points: bool = False
 
     _ground_enable: bool = False
-    _ground_position: Tuple[float, float, float] = (0.0, 0, 0)
+    _ground_position: Tuple[float, float, float] = (0, 0, 0)
     _ground_quat_xyzw: Tuple[float, float, float, float] = (0, 0, 0, 1)
     _ground_size: Tuple[float, float] = (2.0, 2.0)
 
@@ -154,7 +153,7 @@ class Manipulation(task.Task, abc.ABC):
         target_pos = None
 
         if absolute is not None:
-            # If absolute position is selected, simple use the action as the target
+            # If absolute position is selected, directly use the action as target
             target_pos = absolute
         elif relative is not None:
             # Scale relative action to metric units

--- a/drl_grasping/envs/tasks/reach/reach_depth_image.py
+++ b/drl_grasping/envs/tasks/reach/reach_depth_image.py
@@ -7,7 +7,7 @@ import abc
 import gym
 import numpy as np
 
-# TODO: This environment currently does not work with the default CnnPolicy (observation does not match its expectations)
+# TODO: ReachDepthImage environment currently does not currently have a working CnnPolicy
 
 
 class ReachDepthImage(Reach, abc.ABC):


### PR DESCRIPTION
This PR adds option to stack multiple consequent octree observations, similar to Atari stacked frames. This hopefully gives agent a sense of a temporal information from the scene from which it might be able to deduct dynamics.

For the first n observations after reset, octrees are repeated until the buffer is filled.

It is optimised to be processed as a single batch. Therefore, there is little performance loss on system with GPU that has excess of unused pipelines, even if this feature is enabled. 

However, memory usage is effectively multiplied. This is something that would be nice to optimise (the complexity is however out of the scope for this project, as it would require rewriting large portion of off-policy algorithm handling)