### PR TITLE
Octree with proprioceptive observations

### DIFF
--- a/drl_grasping/algorithms/common/features_extractor/octree_cnn.py
+++ b/drl_grasping/algorithms/common/features_extractor/octree_cnn.py
@@ -25,16 +25,18 @@ class OctreeCnnFeaturesExtractor(BaseFeaturesExtractor):
                  full_depth_conv1d: bool = False,
                  full_depth_channels: int = 4,
                  features_dim: int = 64,
+                 aux_obs_dim: int = 0,
                  fast_conv: bool = True,
                  batch_normalization: bool = True):
 
         self._depth = depth
         self._channels_in = channels_in
+        self._aux_obs_dim = aux_obs_dim
         self.n_stacks = observation_space.shape[0]
 
         # Chain up parent constructor
         super(OctreeCnnFeaturesExtractor, self).__init__(observation_space,
-                                                         self.n_stacks*features_dim)
+                                                         self.n_stacks*(features_dim+aux_obs_dim))
 
         # Channels ordered as [channels_in, depth, depth-1, ..., full_depth]
         # I.e [channels_in, channel_multiplier*1, channel_multiplier*2, channel_multiplier*4, channel_multiplier*8,...]
@@ -102,6 +104,9 @@ class OctreeCnnFeaturesExtractor(BaseFeaturesExtractor):
         Note: input octree must be batch of octrees (created with ocnn)
         """
 
+        aux_obs = octree['aux_obs']
+        octree = octree['aux_obs']
+
         # Extract features from the octree at the finest depth
         data = ocnn.octree_property(octree, 'feature', self._depth)
 
@@ -131,5 +136,11 @@ class OctreeCnnFeaturesExtractor(BaseFeaturesExtractor):
         # Feed through the last linear layer
         data = self.linear(data)
 
-        # Return a view that merges stacks into a single feature vector (original batches remain separated)
-        return data.view(-1, self.n_stacks*data.shape[-1])
+        # Get a view that merges stacks into a single feature vector (original batches remain separated)
+        data = data.view(-1, self.n_stacks*data.shape[-1])
+
+        # Concatenate auxiliary observations (if any)
+        if self._aux_obs_dim != 0:
+            data = torch.cat((data, aux_obs), dim=1)
+
+        return data

--- a/drl_grasping/algorithms/common/features_extractor/octree_cnn.py
+++ b/drl_grasping/algorithms/common/features_extractor/octree_cnn.py
@@ -105,14 +105,14 @@ class OctreeCnnFeaturesExtractor(BaseFeaturesExtractor):
         """
 
         aux_obs = octree['aux_obs']
-        octree = octree['aux_obs']
+        octree = octree['octree']
 
         # Extract features from the octree at the finest depth
         data = ocnn.octree_property(octree, 'feature', self._depth)
 
         # Make sure the number of input channels matches the argument passed to constructor
         assert data.size(1) == self._channels_in, \
-            f"Input octree has invalid number of channels. Got {data.size(2)}, expected {self._channels_in}"
+            f"Input octree has invalid number of channels. Got {data.size(1)}, expected {self._channels_in}"
 
         # Pass the data through all convolutional and polling layers
         for i in range(len(self.convs)):
@@ -139,8 +139,10 @@ class OctreeCnnFeaturesExtractor(BaseFeaturesExtractor):
         # Get a view that merges stacks into a single feature vector (original batches remain separated)
         data = data.view(-1, self.n_stacks*data.shape[-1])
 
-        # Concatenate auxiliary observations (if any)
         if self._aux_obs_dim != 0:
+            # Get a view that merges aux feature stacks into a single feature vector (original batches remain separated)
+            aux_obs = aux_obs.view(-1, self.n_stacks*self._aux_obs_dim)
+            # Concatenate auxiliary observations (if any)
             data = torch.cat((data, aux_obs), dim=1)
 
         return data

--- a/drl_grasping/algorithms/common/octree_replay_buffer.py
+++ b/drl_grasping/algorithms/common/octree_replay_buffer.py
@@ -7,7 +7,7 @@ from stable_baselines3.common.buffers import ReplayBuffer
 
 import numpy as np
 import torch as th
-from typing import Optional, Union
+from typing import Optional, Union, Dict
 from stable_baselines3.common.type_aliases import ReplayBufferSamples
 from stable_baselines3.common.vec_env import VecNormalize
 from gym import spaces
@@ -15,10 +15,10 @@ from gym import spaces
 import ocnn
 
 
-def preprocess_stacked_octree_batch(observation: th.Tensor) -> th.Tensor:
+def preprocess_stacked_octree_batch(observation: th.Tensor, device) -> Dict[str, th.Tensor]:
     # Note: Primordial magic is happening here,
     #       but there's no reason to tremble in fear.
-    #       For you own good don't question it too much,
+    #       For your own good don't question it too much,
     #       it's just an optimised stacked octree batch...
 
     octrees = []
@@ -30,7 +30,19 @@ def preprocess_stacked_octree_batch(observation: th.Tensor) -> th.Tensor:
         # Convert to tensor and append to list
         octrees.append(th.from_numpy(octree[:octree_size[0]]))
     # Make batch out of tensor (consisting of n-stacked frames)
-    return ocnn.octree_batch(octrees)
+    octree_batch = ocnn.octree_batch(octrees)
+
+    # Get number of auxiliary observations encoded as float32 and parse them
+    n_aux_obs_f32 = np.frombuffer(buffer=octree[0, 0, -8:-4],
+                                  dtype='uint32',
+                                  count=1)
+    aux_obs = th.from_numpy(
+        np.frombuffer(buffer=observation[:, :, -(4*n_aux_obs_f32+8):-8].reshape(-1),
+                      dtype='float32',
+                      count=n_aux_obs_f32).reshape(observation.shape[:2] + (n_aux_obs_f32,)))
+
+    return {'octree': octree_batch.to(device),
+            'aux_obs': aux_obs.to(device)}
 
 
 __old__init__ = ReplayBuffer.__init__
@@ -71,7 +83,7 @@ def _get_samples_with_support_for_octree(self,
 
     # Current observations
     obs = self.observations[batch_inds, 0, :]
-    obs = preprocess_stacked_octree_batch(obs)
+    obs = preprocess_stacked_octree_batch(obs, self.device)
 
     # Next observations
     if self.optimize_memory_usage:
@@ -79,12 +91,12 @@ def _get_samples_with_support_for_octree(self,
             batch_inds + 1) % self.buffer_size, 0, :]
     else:
         next_obs = self.next_observations[batch_inds, 0, :]
-    next_obs = preprocess_stacked_octree_batch(next_obs)
+    next_obs = preprocess_stacked_octree_batch(next_obs, self.device)
 
     return ReplayBufferSamples(
-        observations=obs.to(self.device),
+        observations=obs,
         actions=self.to_torch(self.actions[batch_inds, 0, :]),
-        next_observations=next_obs.to(self.device),
+        next_observations=next_obs,
         dones=self.to_torch(self.dones[batch_inds]),
         rewards=self.to_torch(self._normalize_reward(
             self.rewards[batch_inds], env)),

--- a/drl_grasping/algorithms/common/octree_replay_buffer.py
+++ b/drl_grasping/algorithms/common/octree_replay_buffer.py
@@ -33,13 +33,13 @@ def preprocess_stacked_octree_batch(observation: th.Tensor, device) -> Dict[str,
     octree_batch = ocnn.octree_batch(octrees)
 
     # Get number of auxiliary observations encoded as float32 and parse them
-    n_aux_obs_f32 = np.frombuffer(buffer=octree[0, 0, -8:-4],
-                                  dtype='uint32',
-                                  count=1)
+    n_aux_obs_f32 = int(np.frombuffer(buffer=observation[0, 0, -8:-4],
+                                      dtype='uint32',
+                                      count=1))
     aux_obs = th.from_numpy(
         np.frombuffer(buffer=observation[:, :, -(4*n_aux_obs_f32+8):-8].reshape(-1),
                       dtype='float32',
-                      count=n_aux_obs_f32).reshape(observation.shape[:2] + (n_aux_obs_f32,)))
+                      count=n_aux_obs_f32*observation.shape[0]*observation.shape[1]).reshape(observation.shape[:2] + (n_aux_obs_f32,)))
 
     return {'octree': octree_batch.to(device),
             'aux_obs': aux_obs.to(device)}

--- a/drl_grasping/algorithms/sac/policies.py
+++ b/drl_grasping/algorithms/sac/policies.py
@@ -270,10 +270,11 @@ class OctreeCnnPolicy(SACPolicy):
             ocnn.write_octree(th.from_numpy(observation[-1]), 'octree.octree')
 
         # Make batch out of tensor (consisting of n-stacked frames)
-        octree_batch = preprocess_stacked_octree_batch(observation)
+        octree_batch = preprocess_stacked_octree_batch(
+            observation, self.device)
 
         with th.no_grad():
-            actions = self._predict(octree_batch.to(self.device),
+            actions = self._predict(octree_batch,
                                     deterministic=deterministic)
         # Convert to numpy
         actions = actions.cpu().numpy()

--- a/drl_grasping/algorithms/td3/policies.py
+++ b/drl_grasping/algorithms/td3/policies.py
@@ -229,10 +229,11 @@ class OctreeCnnPolicy(TD3Policy):
             ocnn.write_octree(th.from_numpy(observation[-1]), 'octree.octree')
 
         # Make batch out of tensor (consisting of n-stacked frames)
-        octree_batch = preprocess_stacked_octree_batch(observation)
+        octree_batch = preprocess_stacked_octree_batch(
+            observation, self.device)
 
         with th.no_grad():
-            actions = self._predict(octree_batch.to(self.device),
+            actions = self._predict(octree_batch,
                                     deterministic=deterministic)
         # Convert to numpy
         actions = actions.cpu().numpy()

--- a/drl_grasping/algorithms/tqc/policies.py
+++ b/drl_grasping/algorithms/tqc/policies.py
@@ -261,10 +261,11 @@ class OctreeCnnPolicy(TQCPolicy):
             ocnn.write_octree(th.from_numpy(observation[-1]), 'octree.octree')
 
         # Make batch out of tensor (consisting of n-stacked frames)
-        octree_batch = preprocess_stacked_octree_batch(observation)
+        octree_batch = preprocess_stacked_octree_batch(
+            observation, self.device)
 
         with th.no_grad():
-            actions = self._predict(octree_batch.to(self.device),
+            actions = self._predict(octree_batch,
                                     deterministic=deterministic)
         # Convert to numpy
         actions = actions.cpu().numpy()

--- a/drl_grasping/envs/tasks/__init__.py
+++ b/drl_grasping/envs/tasks/__init__.py
@@ -129,6 +129,7 @@ register(
             'octree_include_color': False,
             'octree_n_stacked': 2,
             'octree_max_size': 30000,
+            'proprieceptive_observations': False,
             'verbose': False,
             })
 register(

--- a/drl_grasping/envs/tasks/__init__.py
+++ b/drl_grasping/envs/tasks/__init__.py
@@ -169,5 +169,6 @@ register(
             'octree_include_color': True,
             'octree_n_stacked': 2,
             'octree_max_size': 100000,
+            'proprieceptive_observations': False,
             'verbose': False,
             })

--- a/drl_grasping/envs/tasks/grasp/grasp.py
+++ b/drl_grasping/envs/tasks/grasp/grasp.py
@@ -114,6 +114,9 @@ class Grasp(Manipulation, abc.ABC):
 
         self._original_workspace_volume = self._workspace_volume
 
+        # Indicates whether gripper is opened or closed
+        self._gripper_state = 1.0
+
     def create_action_space(self) -> ActionSpace:
 
         if self._full_3d_orientation:
@@ -153,8 +156,10 @@ class Grasp(Manipulation, abc.ABC):
         gripper_action = action[0]
         if gripper_action < -self._gripper_dead_zone:
             self.moveit2.gripper_close(manual_plan=True)
+            self._gripper_state = -1.0
         elif gripper_action > self._gripper_dead_zone:
             self.moveit2.gripper_open(manual_plan=True)
+            self._gripper_state = 1.0
         else:
             # No-op for the gripper as it is in the dead zone
             pass
@@ -210,6 +215,8 @@ class Grasp(Manipulation, abc.ABC):
     def reset_task(self):
 
         self.curriculum.reset_task()
+
+        self._gripper_state = 1.0
 
         if self._verbose:
             print(f"\ntask reset")

--- a/drl_grasping/envs/tasks/manipulation.py
+++ b/drl_grasping/envs/tasks/manipulation.py
@@ -207,8 +207,7 @@ class Manipulation(task.Task, abc.ABC):
 
         elif relative is not None:
             # Get current orientation
-            current_quat_xyzw = conversions.Quaternion.to_xyzw(
-                self.get_ee_orientation())
+            current_quat_xyzw = self.get_ee_orientation()
 
             # For 'z' representation, result should always point down
             # Therefore, create a new quatertnion that contains only yaw component
@@ -258,4 +257,4 @@ class Manipulation(task.Task, abc.ABC):
         """
 
         robot = self.world.get_model(self.robot_name).to_gazebo()
-        return robot.get_link(self.robot_ee_link_name).orientation()
+        return conversions.Quaternion.to_xyzw(robot.get_link(self.robot_ee_link_name).orientation())

--- a/hyperparams/tqc.yml
+++ b/hyperparams/tqc.yml
@@ -52,6 +52,7 @@ Grasp-OctreeWithColor-Gazebo-v0:
       features_dim: 256
       fast_conv: True
       batch_normalization: True
+      aux_obs_dim: 0
     n_quantiles: 20
     net_arch: [512, 512]
   env_wrapper:


### PR DESCRIPTION
Implements https://github.com/AndrejOrsula/drl_grasping/issues/38

Adds end-effector position, orientation and gripper state to observations space alongside octree. These proprioceptive observations are stacked together with octrees (if octree stacking is enabled).

Due to the current lack of Dict obs support in stable-baselines3 (track PR https://github.com/DLR-RM/stable-baselines3/pull/243), this implementation is kinda hacky, but works...