### PR TITLE
Add scripts for interacting with model dataset from Fuel (training+testing)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ ament_python_install_module(
 # Install scripts
 set(SCRIPTS_DIR scripts)
 install(PROGRAMS
+    ${SCRIPTS_DIR}/utils/dataset/dataset_download_test.bash
+    ${SCRIPTS_DIR}/utils/dataset/dataset_download_train.bash
+    ${SCRIPTS_DIR}/utils/dataset/dataset_set_test.bash
+    ${SCRIPTS_DIR}/utils/dataset/dataset_set_train.bash
+    ${SCRIPTS_DIR}/utils/dataset/dataset_unset_test.bash
+    ${SCRIPTS_DIR}/utils/dataset/dataset_unset_train.bash
     ${SCRIPTS_DIR}/utils/process_collection.py
     ${SCRIPTS_DIR}/enjoy.py
     ${SCRIPTS_DIR}/train.py

--- a/drl_grasping/envs/models/random_ground.py
+++ b/drl_grasping/envs/models/random_ground.py
@@ -37,6 +37,15 @@ class RandomGround(model_wrapper.ModelWrapper):
         if texture_dir is not None:
             # Get list of the available textures
             textures = os.listdir(texture_dir)
+            # Keep only texture directories if texture_dir is a git repo (ugly fix)
+            try:
+                textures.remove('.git')
+            except:
+                pass
+            try:
+                textures.remove('README.md')
+            except:
+                pass
 
             # Choose a random texture from these
             random_texture_dir = os.path.join(texture_dir,

--- a/drl_grasping/utils/model_collection_randomizer.py
+++ b/drl_grasping/utils/model_collection_randomizer.py
@@ -107,19 +107,19 @@ class ModelCollectionRandomizer():
         return model_paths
 
     def random_model(self,
-                     min_scale=0.15,
-                     max_scale=0.2,
+                     min_scale=0.125,
+                     max_scale=0.175,
                      min_mass=0.05,
                      max_mass=0.25,
                      min_friction=0.75,
                      max_friction=1.5,
-                     decimation_fraction_of_visual=0.025,
-                     decimation_min_faces=8,
-                     decimation_max_faces=400,
+                     decimation_fraction_of_visual=0.25,
+                     decimation_min_faces=40,
+                     decimation_max_faces=200,
                      max_faces=40000,
                      max_vertices=None,
-                     component_min_faces_fraction=0.05,
-                     component_max_volume_fraction=0.1,
+                     component_min_faces_fraction=0.1,
+                     component_max_volume_fraction=0.35,
                      fix_mtl_texture_paths=True,
                      skip_blacklisted=True,
                      return_sdf_path=True) -> str:
@@ -176,8 +176,8 @@ class ModelCollectionRandomizer():
                            decimation_max_faces=400,
                            max_faces=40000,
                            max_vertices=None,
-                           component_min_faces_fraction=0.05,
-                           component_max_volume_fraction=0.1,
+                           component_min_faces_fraction=0.1,
+                           component_max_volume_fraction=0.35,
                            fix_mtl_texture_paths=True):
         if self._unique_cache:
             model_paths = self._model_paths
@@ -204,9 +204,9 @@ class ModelCollectionRandomizer():
 
     def process_model(self,
                       model_path,
-                      decimation_fraction_of_visual=0.025,
-                      decimation_min_faces=8,
-                      decimation_max_faces=400,
+                      decimation_fraction_of_visual=0.25,
+                      decimation_min_faces=40,
+                      decimation_max_faces=200,
                       max_faces=40000,
                       max_vertices=None,
                       component_min_faces_fraction=0.05,

--- a/scripts/utils/dataset/dataset_download_test.bash
+++ b/scripts/utils/dataset/dataset_download_test.bash
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+owner="googleresearch"
+model_names="3d_dollhouse_sofa
+             dino_4
+             nintendo_mario_action_figure
+             android_figure_orange
+             dpc_handmade_hat_brown
+             olive_kids_robots_pencil_case
+             bia_cordon_bleu_white_porcelain_utensil_holder_900028
+             germanium_ge132
+             schleich_african_black_rhino
+             central_garden_flower_pot_goo_425
+             grandmother
+             schleich_s_bayala_unicorn_70432
+             chelsea_lo_fl_rdheel_zaqrnhlefw8
+             kong_puppy_teething_rubber_small_pink
+             school_bus
+             cole_hardware_butter_dish_square_red
+             lenovo_yoga_2_11
+             weisshai_great_white_shark
+             cole_hardware_school_bell_solid_brass_38
+             mini_fire_engine"
+
+if [[ -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" ]]; then
+    echo "Error: There are already some models inside "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models". Please move them to a temporary location before continuing. If you have downloaded training dataset bofere, please use 'ros2 run drl_grasping dataset_unset_train.bash' ('ros2 run drl_grasping set_dataset_train.bash' to reactivate it)."
+    exit 1
+fi
+
+for model_name in $model_names; do
+    if [[ ! -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models/$model_name" ]]; then
+        model_uri="https://fuel.ignitionrobotics.org/1.0/$owner/models/$model_name"
+        echo "Info: Downloading model '$model_uri'"
+        ign fuel download -t model -u "$model_uri" &
+    fi
+done
+for job in $(jobs -p); do
+    wait $job
+    echo "Info: Model downloaded"
+done

--- a/scripts/utils/dataset/dataset_download_train.bash
+++ b/scripts/utils/dataset/dataset_download_train.bash
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+owner="googleresearch"
+model_names="3d_dollhouse_happy_brother
+             ecoforms_plant_container_urn_55_mocha
+             3d_dollhouse_lamp
+             f5_trx_fg
+             3d_dollhouse_refrigerator
+             fire_engine
+             3d_dollhouse_sink
+             folic_acid
+             3d_dollhouse_swing
+             grandfather_doll
+             3d_dollhouse_tablepurple
+             granimals_20_wooden_abc_blocks_wagon
+             3m_vinyl_tape_green_1_x_36_yd
+             heavyduty_flashlight
+             45oz_ramekin_asst_deep_colors
+             imaginext_castle_ogre
+             ace_coffee_mug_kristen_16_oz_cup
+             lacing_sheep
+             air_hogs_wind_flyers_set_airplane_red
+             markings_letter_holder
+             android_figure_panda
+             mens_santa_cruz_thong_in_tan_r59c69darph
+             animal_planet_foam_2headed_dragon
+             mini_excavator
+             baby_elements_stacking_cups
+             mini_roller
+             balancing_cactus
+             my_little_pony_princess_celestia
+             bia_porcelain_ramekin_with_glazed_rim_35_45_oz_cup
+             nickelodeon_teenage_mutant_ninja_turtles_leonardo
+             big_dot_aqua_pencil_case
+             nikon_1_aw1_w11275mm_lens_silver
+             black_and_decker_tr3500sd_2slice_toaster
+             nintendo_yoshi_action_figure
+             blackblack_nintendo_3dsxl
+             nordic_ware_original_bundt_pan
+             bradshaw_international_11642_7_qt_mp_plastic_bowl
+             olive_kids_birdie_munch_n_lunch
+             breyer_horse_of_the_year_2015
+             peekaboo_roller
+             brisk_iced_tea_lemon_12_12_fl_oz_355_ml_cans_144_fl_oz_426_lt
+             playmates_industrial_cosplinter_teenage_mutant_ninja_turtle_action_figure
+             brother_lc_1053pks_ink_cartridge_cyanmagentayellow_1pack
+             playmates_nickelodeon_teenage_mutant_ninja_turtles_shredder
+             bunny_racer
+             retail_leadership_summit_ect3zqhyikx
+             calphalon_kitchen_essentials_12_cast_iron_fry_pan_black
+             room_essentials_mug_white_yellow
+             canon_225226_ink_cartridges_blackcolor_cyan_magenta_yellow_6_count
+             schleich_allosaurus
+             chefmate_8_frypan
+             schleich_hereford_bull
+             chelsea_blkheelpmp_dwxltznxlzz
+             schleich_lion_action_figure
+             chicken_nesting
+             schleich_spinosaurus_action_figure
+             circo_fish_toothbrush_holder_14995988
+             schleich_therizinosaurus_ln9cruulpqc
+             closetmaid_premium_fabric_cube_red
+             shaxon_100_molded_category_6_rj45rj45_shielded_patch_cord_white
+             coast_guard_boat
+             spiderman_titan_hero_12inch_action_figure_5hnn4mtkfsp
+             cole_hardware_antislip_surfacing_material_white
+             stacking_bear
+             colton_wntr_chukka_y4jo0i8jqfw
+             stacking_ring
+             craftsman_grip_screwdriver_phillips_cushion
+             thomas_friends_wooden_railway_talking_thomas_z7yi7ufhjrj
+             crazy_shadow_2
+             threshold_porcelain_pitcher_white
+             crosley_alarm_clock_vintage_metal
+             victor_reversible_bookend
+             digital_camo_double_decker_lunch_bag
+             weston_no_33_signature_sausage_tonic_12_fl_oz
+             dino_3
+             whale_whistle_6pcs_set
+             dino_5
+             wooden_abc_123_blocks_50_pack
+             ecoforms_plant_container_qp6coral
+             xyli_pure_xylitol"
+
+if [[ -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" ]]; then
+    echo "Error: There are already some models inside "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models". Please move them to a temporary location before continuing. If you have downloaded testing dataset bofere, please use 'ros2 run drl_grasping dataset_unset_test.bash' ('ros2 run drl_grasping set_dataset_test.bash' to reactivate it)."
+    exit 1
+fi
+
+for model_name in $model_names; do
+    if [[ ! -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models/$model_name" ]]; then
+        model_uri="https://fuel.ignitionrobotics.org/1.0/$owner/models/$model_name"
+        echo "Info: Downloading model '$model_uri'"
+        ign fuel download -t model -u "$model_uri" &
+    fi
+done
+for job in $(jobs -p); do
+    wait $job
+    echo "Info: Model downloaded"
+done
+
+echo "Info: All models downloaded. Note: Downloaded models are combined with whatever models were already inside "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" and all of these will be treated as training dataset."

--- a/scripts/utils/dataset/dataset_set_test.bash
+++ b/scripts/utils/dataset/dataset_set_test.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+owner="googleresearch"
+test_model_dir="models_test"
+
+if [[ -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir" ]]; then
+    if [[ ! -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" ]]; then
+        echo "Info: Setting all models under "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir" and moving them to "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models"."
+        mv "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir" "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models"
+    else
+        echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" already exists. Setting of testing dataset skipped."
+        exit 1
+    fi
+else
+    echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir" does not exist. Setting of testing dataset skipped. Please make sure to download testing dataset first."
+    echo "Info: Setting of dataset has only an effect if the dataset was previously unset."
+    exit 1
+fi

--- a/scripts/utils/dataset/dataset_set_train.bash
+++ b/scripts/utils/dataset/dataset_set_train.bash
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+owner="googleresearch"
+train_model_dir="models_train"
+
+if [[ -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir" ]]; then
+    if [[ ! -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" ]]; then
+        echo "Info: Setting all models under "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir" and moving them to "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models"."
+        mv "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir" "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models"
+    else
+        echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" already exists. Setting of training dataset skipped."
+        exit 1
+    fi
+else
+    echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir" does not exist. Setting of training dataset skipped. Please make sure to download training dataset first."
+    echo "Info: Setting of dataset has only an effect if the dataset was previously unset."
+    exit 1
+fi

--- a/scripts/utils/dataset/dataset_unset_test.bash
+++ b/scripts/utils/dataset/dataset_unset_test.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+owner="googleresearch"
+test_model_dir="models_test"
+
+if [[ -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" ]]; then
+    if [[ ! -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir" ]]; then
+        echo "Info: Unsetting all models under "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" and moving them to temporary directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir". Use 'ros2 run drl_grasping dataset_set_test.bash' to reactivate."
+        mv "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir"
+    else
+        echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$test_model_dir" already exists. Unsetting of testing dataset skipped."
+        exit 1
+    fi
+else
+    echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" does not exist. Unsetting of testing dataset skipped. Please make sure to download testing dataset first."
+    exit 1
+fi

--- a/scripts/utils/dataset/dataset_unset_train.bash
+++ b/scripts/utils/dataset/dataset_unset_train.bash
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+owner="googleresearch"
+train_model_dir="models_train"
+
+if [[ -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" ]]; then
+    if [[ ! -d "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir" ]]; then
+        echo "Info: Unsetting all models under "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" and moving them to temporary directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir". Use 'ros2 run drl_grasping dataset_set_train.bash' to reactivate"
+        mv "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir"
+    else
+        echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/$train_model_dir" already exists. Unsetting of training dataset skipped."
+        exit 1
+    fi
+else
+    echo "Error: Directory "$HOME/.ignition/fuel/fuel.ignitionrobotics.org/$owner/models" does not exist. Unsetting of training dataset skipped. Please make sure to download training dataset first."
+    exit 1
+fi

--- a/scripts/utils/process_collection.py
+++ b/scripts/utils/process_collection.py
@@ -13,13 +13,13 @@ def main(args=None):
                                                             unique_cache=True,
                                                             enable_blacklisting=True)
     print("Processing all models from owner [%s]..." % args.owner)
-    model_collection_randomizer.process_all_models(decimation_fraction_of_visual=0.025,
-                                                   decimation_min_faces=8,
-                                                   decimation_max_faces=400,
+    model_collection_randomizer.process_all_models(decimation_fraction_of_visual=args.decimate_fraction,
+                                                   decimation_min_faces=args.decimate_min_faces,
+                                                   decimation_max_faces=args.decimate_max_faces,
                                                    max_faces=40000,
                                                    max_vertices=None,
-                                                   component_min_faces_fraction=0.05,
-                                                   component_max_volume_fraction=0.1,
+                                                   component_min_faces_fraction=0.1,
+                                                   component_max_volume_fraction=0.35,
                                                    fix_mtl_texture_paths=True)
     print("Processing finished")
 
@@ -46,6 +46,18 @@ if __name__ == "__main__":
                         action='store',
                         default='1.0',
                         help='Version of the Fuel server')
+    parser.add_argument('--decimate_fraction',
+                        action='store',
+                        default='0.25',
+                        help='Fraction of faces collision geometry should have compared to visual geometry (min/max faces will be enforced)')
+    parser.add_argument('--decimate_min_faces',
+                        action='store',
+                        default='40',
+                        help='Min number of faces for collision geometry')
+    parser.add_argument('--decimate_max_faces',
+                        action='store',
+                        default='200',
+                        help='Max number of faces for collision geometry')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR adds very simple bash scripts for downloading, setting and unsetting training and testing datasets.

Models in these datasets were selected randomly from [Google Scanned Objects](https://app.ignitionrobotics.org/GoogleResearch/fuel/collections/Google%20Scanned%20Objects) collection, where training contains 80 models and testing 20 models. Depending on available system memory, 80 objects might be too many due to upstream memory leak - see https://github.com/AndrejOrsula/drl_grasping/issues/20. If that is the case, simply remove some of the models from the download script(s)...